### PR TITLE
fix: main template formatting

### DIFF
--- a/internal/templates/main.tmpl
+++ b/internal/templates/main.tmpl
@@ -3,7 +3,7 @@
 {{ else -}}
 #include <stdio.h>
 {{ end }}
-int main (int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
     {{- if eq .Language "cpp" }}
     std::cout << "Hello World" << std::endl;


### PR DESCRIPTION
- Remove trailing spaces from the template for the main function